### PR TITLE
Add Name corrections case study content

### DIFF
--- a/static/data/data.js
+++ b/static/data/data.js
@@ -1154,12 +1154,161 @@ export const data = {
         "Helped bookers to add their “correct” name, to avoid issues at flight check-in or even boarding. Reduced this type of tickets by 50%",
       image: "name-corrections/hero.png",
       isExternal: false,
-      tldr: "TBA",
+      tldr: "TODO: Name correction tickets add +0.17 to contact ratio and take 45+ minutes each to resolve. We tackled this with a series of checkout improvements that encourage bookers to check and edit traveller names, plus a fix for how special characters are handled.",
       summary: {
         year: "2025 - 2026",
         role: "product designer",
         team: "collaborated with PM, engineers",
       },
+      content: [
+        {
+          type: "TitleAndText",
+          title: "The problem",
+          content: [
+            {
+              type: "body",
+              text: "When a flight booking is made, the name sent to the provider doesn't always match the traveller's legal name on their passport. Once a booking is made, fixing the name is expensive: it takes Customer Care 45+ minutes on average, and in some cases airlines won't allow the correction at all.",
+            },
+            {
+              type: "list",
+              list: [
+                "Name corrections add +0.17 to contact ratio, with 45+ minutes AHT per ticket",
+                "79% of name correction cases happen when the booker isn't the traveller",
+              ],
+            },
+            {
+              type: "body",
+              text: "Most of these tickets come from flight bookings where no travel document was provided, so the booking falls back to the traveller's profile name - often a preferred name, not their legal one. The fact that the majority of cases happen when the booker isn't the traveller made it clear this wasn't just a typo problem - it was a visibility problem.",
+            },
+          ],
+        },
+        {
+          type: "ImageWithCaption",
+          caption: "TODO: add image - hero/overview of the name corrections problem (e.g. Looker chart of contact ratio, or a booking with a mismatched name)",
+          image: "name-corrections/hero.png",
+        },
+        {
+          type: "Divider",
+        },
+        {
+          type: "TitleAndText",
+          title: "Our first hypothesis: documents are the answer",
+          content: [
+            {
+              type: "body",
+              text: "When we looked at where name corrections were coming from, one pattern stood out - bookings that had a travel document attached almost never ran into this problem. That made the first solution feel obvious: if having a document on file solves it, why not require one for every booking? It's the kind of fix that looks airtight from the data alone, and it became our starting point.",
+            },
+          ],
+        },
+        {
+          type: "ImageWithCaption",
+          caption: "TODO: add image - early concept of forcing a travel document at checkout",
+          image: "name-corrections/hypothesis-placeholder.png",
+        },
+        {
+          type: "Divider",
+        },
+        {
+          type: "TitleAndText",
+          title: "Testing that hypothesis against reality",
+          content: [
+            {
+              type: "body",
+              text: "Before committing to that direction, we looked at how other travel platforms handle this - and even for international flights, most don't require a passport to book. That was the first signal something was off.",
+            },
+            {
+              type: "body",
+              text: "So I ran the numbers on our own bookings, and the gap was stark: around 4,000 flight bookings a week would now need an extra step, to address roughly 150 cases where the name was actually wrong. Internally, that comparison was enough to change the direction of the project.",
+            },
+            {
+              type: "list",
+              list: [
+                "~150 problem cases per week",
+                "~4,000 bookings per week affected by a new requirement",
+                "Other OTAs only require documents for international flights",
+              ],
+            },
+          ],
+        },
+        {
+          type: "ImageWithCaption",
+          caption: "TODO: add image - competitive analysis of other OTAs / quantitative breakdown (4,000 vs 150)",
+          image: "name-corrections/analysis-placeholder.png",
+        },
+        {
+          type: "Divider",
+        },
+        {
+          type: "TitleAndText",
+          title: "A lighter-touch solution",
+          content: [
+            {
+              type: "body",
+              text: "So the question became: how do we get the same outcome - a correct name on the booking - without adding a step for everyone? The traveller's name was already there, but it was buried inside a details modal that most bookers never opened.",
+            },
+            {
+              type: "body",
+              text: "We added a checkbox prompting bookers to confirm the name matched the traveller's legal name, and made that name visible without extra clicks. The next step builds on this directly - exposing the name fields inline on checkout, so reviewing and editing happens in place.",
+            },
+          ],
+        },
+        {
+          type: "ImageWithCaption",
+          caption: "TODO: add image - checkout checkbox and improved traveller name visibility",
+          image: "name-corrections/checkbox-placeholder.png",
+        },
+        {
+          type: "ImageWithCaption",
+          caption: "TODO: add image - inline editable name fields at checkout (next phase)",
+          image: "name-corrections/inline-fields-placeholder.png",
+        },
+        {
+          type: "Divider",
+        },
+        {
+          type: "TitleAndText",
+          title: "Fixing the edge cases",
+          content: [
+            {
+              type: "body",
+              text: "A smaller piece of this - around 4% of cases - came down to how special characters get handled. Some providers would turn a character like \"ä\" into \"a\" instead of \"ae\", and reject the booking outright. That's a backend fix rather than a UI one: correcting the normalisation logic when a travel document is added, and showing a clear message if a character is going to change.",
+            },
+          ],
+        },
+        {
+          type: "ImageWithCaption",
+          caption: "TODO: add image - special character normalisation message at document upload",
+          image: "name-corrections/special-characters-placeholder.png",
+        },
+        {
+          type: "Divider",
+        },
+        {
+          type: "ImpactCallOut",
+          title: "Results so far",
+          subtitle:
+            "The first set of changes - the checkbox and improved visibility - went live at the end of March. By the time we checked the numbers in May, the contact ratio had already dropped, before the inline editing or special character fix had even shipped.",
+          content: [
+            {
+              top_content: "↓ name corrections contact ratio",
+              bottom_content: "From 0.17 (Jan) to 0.12 (March)",
+            },
+          ],
+        },
+        {
+          type: "Divider",
+        },
+        {
+          type: "TitleAndText",
+          title: "What this taught me",
+          content: [
+            {
+              type: "body",
+              text: "What stuck with me from this project is that the data pointing toward \"documents reduce mismatches\" was true - but it didn't account for the cost of applying that fix everywhere. Comparing against what other platforms do, and running the numbers on our own bookings, turned a sweeping requirement into a much smaller, more targeted change. And that smaller change is already showing results.",
+            },
+          ],
+        },
+      ],
     },
   ],
 };


### PR DESCRIPTION
Builds out the project content for the Name corrections case study, following a hypothesis-and-evidence narrative: the initial idea to require travel documents on every booking, the data that showed it would add friction to far more bookings than it would fix, and the lighter-touch checkout solution shipped instead.